### PR TITLE
0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,16 @@
 
 ***All notable changes to this project will be documented in this file.***
 
-## [Unreleased]
+## [0.0.4](https://github.com/M3str3/HexSpell/pull/9) - 2025-08-02
 
 ### Added
 - Added testing for ***PE***, ***ELF*** & ***Mach-O*** to ensure errors are raised on invalid formats.
-
-### Changed
-- *(none yet)*
 
 ### Fixed
 - In ***ELF*** & ***Mach-O*** parsers, conversion errors now propagate to `FileParseError::BufferOverflow` instead of panicking.
 - In ***PeSection*** string extraction, invalid ranges errors now propagate to  `FileParseError::BufferOverflow` instead of panicking.
 - In ***Field*** values that exceed the attribute's limits now propagate `FileParseError::BufferOverflow` instead of panicking.
+
 
 
 ## [0.0.3](https://github.com/M3str3/HexSpell/pull/6) - 2024-09-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 - In ***ELF*** & ***Mach-O*** parsers, conversion errors now propagate to `FileParseError::BufferOverflow` instead of panicking.
+- In ***PE*** section string extraction, invalid ranges now return `FileParseError::BufferOverflow` rather than panicking.
 
 ## [0.0.3](https://github.com/M3str3/HexSpell/pull/6) - 2024-09-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
 ### Fixed
 - In ***ELF*** & ***Mach-O*** parsers, conversion errors now propagate to `FileParseError::BufferOverflow` instead of panicking.
-- In ***PE*** section string extraction, invalid ranges now return `FileParseError::BufferOverflow` rather than panicking.
+- In ***PeSection*** string extraction, invalid ranges errors now propagate to  `FileParseError::BufferOverflow` instead of panicking.
+- In ***Field*** values that exceed the attribute's limits now propagate `FileParseError::BufferOverflow` instead of panicking.
+
 
 ## [0.0.3](https://github.com/M3str3/HexSpell/pull/6) - 2024-09-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,38 +1,54 @@
 # Changelog
 
-## [0.0.3](https://github.com/M3str3/HexSpell/pull/6) - 2024-09-23
+***All notable changes to this project will be documented in this file.***
+
+## [Unreleased]
+
+### Added
+- *(none yet)*
+
+### Changed
+- *(none yet)*
+
 ### Fixed
-#### PE
-- [**Bug #5**](https://github.com/M3str3/HexSpell/issues/5): Fixed overflow in the `calc_checksum` function. The `checksum` variable was previously a `u32`, which could lead to overflow during the checksum calculation in PE files. The fix now uses `u64` during the calculation to prevent overflow, but the function still returns a `u32` as expected.
-- [**Bug #4**](https://github.com/M3str3/HexSpell/issues/4): Adjusted `sizeofheaders` when adding a new section with `add_section`. The previous implementation did not account for the case where the new section could not fit within the existing `sizeofheaders`. The fix ensures that if the new section doesn't fit, `sizeofheaders` is increased and aligned with `filealignment`, pushing back the content, including the entry point, to make space.
+- In ***ELF*** & ***Mach-O*** parsers, conversion errors now propagate to `FileParseError::BufferOverflow` instead of panicking.
+
+## [0.0.3](https://github.com/M3str3/HexSpell/pull/6) - 2024-09-23
+
+### Fixed
+- **Bug #5**: Prevented overflow in `calc_checksum` by performing calculations in `u64` before casting back to `u32`. ([#5](https://github.com/M3str3/HexSpell/issues/5))  
+- **Bug #4**: When adding a new section via `add_section`, ensure `sizeofheaders` grows (and is aligned to `filealignment`) if the section doesn’t fit, shifting the rest of the file (including the entry point) accordingly. ([#4](https://github.com/M3str3/HexSpell/issues/4))
+
+
 
 ## [0.0.2](https://github.com/M3str3/HexSpell/pull/3) - 2024-09-14
-### Added
-- New examples for PE, ELF, and Mach-O in the `readme.md`.
-- New MachO binary for testing.
-- Added basic integration and testing for Mach-O files.
 
-### Refactored
-- **Tests (MachO & ELF)**: Simplified test cases by using `is_empty()` instead of `!= ""`.
-- **Utils**: Refactored utility functions to use `map` for byte conversion in extraction functions.
-- **Field struct**: Updated buffer parameter from `Vec<u8>` to `&mut [u8]`.
-- **PE/Header**: Moved from using `to_string` to implementing the `fmt::Display` trait for cleaner string formatting.
-- **General formatting**: Applied `cargo fmt` to format code consistently.
-  
+### Added
+- Initial support for ***Mach-O*** format.  
+- Additional ***Mach-O*** test binary.  
+- New examples for PE, ELF and Mach-O in `README.md`.  
+
+### Changed
+- Simplified ***Mach-O*** & ***ELF*** tests to use `is_empty()` instead of comparing with `!= ""`.  
+- Refactored utility functions to use `Iterator::map` for byte conversions.  
+- Updated `Field` struct to accept `&mut [u8]` instead of `Vec<u8]`.  
+- In ***PE*** module, replaced `to_string` calls with `fmt::Display` implementations for cleaner formatting.  
+- Added `rustfmt.toml` to define project-wide formatting rules and ran `cargo fmt`.  
+- Removed unnecessary type conversions in the ***PE*** code.
+
 ### Fixed
-- Fixed spelling mistakes in various files.
-  
-### Chore
-- Added `rustfmt.toml` file to define code formatting rules.
-- Removed unnecessary type conversions in the PE module.
+- Corrected typos and spelling mistakes throughout the codebase.
 
 ### Documentation
-- Updated `tests/readme.md` with more documentation and examples.
-- Added new generator script to automate the creation of `tests.toml` files.
+- Expanded `tests/readme.md` with more examples and explanations.  
+- Introduced a generator script to automate creation of `tests.toml`.
+
+
 
 ## [0.0.1](https://github.com/M3str3/HexSpell/pull/2) - 2024-05-22
+
 ### Added
-- Initial support for PE (Portable Executable) format.
-- Initial support for ELF (Executable and Linkable Format).
-- Basic tests for PE and ELF file structures.
-- Core functionality for reading and parsing PE and ELF headers.
+- Initial support for ***PE*** (Portable Executable) format.  
+- Initial support for ***ELF*** (Executable and Linkable Format).  
+- Core parsing functionality for ***PE*** & ***ELF*** headers.  
+- Basic unit tests for ***PE*** & ***ELF*** structures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## [Unreleased]
 
 ### Added
-- *(none yet)*
+- Added testing for ***PE***, ***ELF*** & ***Mach-O*** to ensure errors are raised on invalid formats.
 
 ### Changed
 - *(none yet)*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hexspell"
-version = "0.0.3"
+version = "0.0.4"
 authors=["Mestre <namestre3@protonmail.com>"]
 edition = "2021"
 description = "A open source lib to parse executables in Rust"

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ fn main() {
     print!("Old entry point: {:X} | ", pe.header.entry_point.value);
 
     // Update the entry point to a new value, on the same pe.buffer
-    pe.header.entry_point.update(&mut pe.buffer, 0x36D4u32);
+    pe.header.entry_point.update(&mut pe.buffer, 0x36D4u32).unwrap();
 
     // Print new entry point
     print!("New entry point: {:X}", pe.header.entry_point.value);
@@ -184,7 +184,7 @@ fn main(){
     pe.add_section(new_section_header, shellcode.to_vec()).expect("[!] Error adding new section into PE");
 
     // Optional: Update entry point to execute our payload instead of the original code
-    pe.header.entry_point.update(&mut pe.buffer, pe.sections.last().unwrap().virtual_address.value);
+    pe.header.entry_point.update(&mut pe.buffer, pe.sections.last().unwrap().virtual_address.value).unwrap();
 
     // Write output to a new file
     pe.write_file("tests/out/modified.exe").expect("[!] Error writing new PE to disk");

--- a/src/elf/program.rs
+++ b/src/elf/program.rs
@@ -29,43 +29,75 @@ impl ProgramHeader {
                 return Err(errors::FileParseError::BufferOverflow);
             }
 
-            let p_type = Field::new(
-                u32::from_le_bytes(buffer[base..base + 4].try_into().unwrap()),
+            let p_type: Field<u32> = Field::new(
+                u32::from_le_bytes(
+                    buffer[base..base + 4]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base,
                 4,
             );
-            let p_flags = Field::new(
-                u32::from_le_bytes(buffer[base + 4..base + 8].try_into().unwrap()),
+            let p_flags: Field<u32> = Field::new(
+                u32::from_le_bytes(
+                    buffer[base + 4..base + 8]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 4,
                 4,
             );
-            let p_offset = Field::new(
-                u64::from_le_bytes(buffer[base + 8..base + 16].try_into().unwrap()),
+            let p_offset: Field<u64> = Field::new(
+                u64::from_le_bytes(
+                    buffer[base + 8..base + 16]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 8,
                 8,
             );
-            let p_vaddr = Field::new(
-                u64::from_le_bytes(buffer[base + 16..base + 24].try_into().unwrap()),
+            let p_vaddr: Field<u64> = Field::new(
+                u64::from_le_bytes(
+                    buffer[base + 16..base + 24]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 16,
                 8,
             );
-            let p_paddr = Field::new(
-                u64::from_le_bytes(buffer[base + 24..base + 32].try_into().unwrap()),
+            let p_paddr: Field<u64> = Field::new(
+                u64::from_le_bytes(
+                    buffer[base + 24..base + 32]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 24,
                 8,
             );
-            let p_filesz = Field::new(
-                u64::from_le_bytes(buffer[base + 32..base + 40].try_into().unwrap()),
+            let p_filesz: Field<u64> = Field::new(
+                u64::from_le_bytes(
+                    buffer[base + 32..base + 40]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 32,
                 8,
             );
-            let p_memsz = Field::new(
-                u64::from_le_bytes(buffer[base + 40..base + 48].try_into().unwrap()),
+            let p_memsz: Field<u64> = Field::new(
+                u64::from_le_bytes(
+                    buffer[base + 40..base + 48]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 40,
                 8,
             );
-            let p_align = Field::new(
-                u64::from_le_bytes(buffer[base + 48..base + 56].try_into().unwrap()),
+            let p_align: Field<u64> = Field::new(
+                u64::from_le_bytes(
+                    buffer[base + 48..base + 56]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 48,
                 8,
             );

--- a/src/elf/section.rs
+++ b/src/elf/section.rs
@@ -32,52 +32,92 @@ impl SectionHeader {
             }
 
             let sh_name = Field::new(
-                u32::from_le_bytes(buffer[base..base + 4].try_into().unwrap()),
+                u32::from_le_bytes(
+                    buffer[base..base + 4]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base,
                 4,
             );
             let sh_type = Field::new(
-                u32::from_le_bytes(buffer[base + 4..base + 8].try_into().unwrap()),
+                u32::from_le_bytes(
+                    buffer[base + 4..base + 8]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 4,
                 4,
             );
             let sh_flags = Field::new(
-                u64::from_le_bytes(buffer[base + 8..base + 16].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 8..base + 16]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 8,
                 8,
             );
             let sh_addr = Field::new(
-                u64::from_le_bytes(buffer[base + 16..base + 24].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 16..base + 24]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 16,
                 8,
             );
             let sh_offset = Field::new(
-                u64::from_le_bytes(buffer[base + 24..base + 32].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 24..base + 32]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 24,
                 8,
             );
             let sh_size = Field::new(
-                u64::from_le_bytes(buffer[base + 32..base + 40].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 32..base + 40]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 32,
                 8,
             );
             let sh_link = Field::new(
-                u32::from_le_bytes(buffer[base + 40..base + 44].try_into().unwrap()),
+                u32::from_le_bytes(
+                    buffer[base + 40..base + 44]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 40,
                 4,
             );
             let sh_info = Field::new(
-                u32::from_le_bytes(buffer[base + 44..base + 48].try_into().unwrap()),
+                u32::from_le_bytes(
+                    buffer[base + 44..base + 48]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 44,
                 4,
             );
             let sh_addralign = Field::new(
-                u64::from_le_bytes(buffer[base + 48..base + 56].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 48..base + 56]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 48,
                 8,
             );
             let sh_entsize = Field::new(
-                u64::from_le_bytes(buffer[base + 56..base + 64].try_into().unwrap()),
+                u64::from_le_bytes(
+                    buffer[base + 56..base + 64]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 base + 56,
                 8,
             );

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,12 +13,12 @@ pub enum FileParseError {
 impl fmt::Display for FileParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            FileParseError::Io(err) => write!(f, "I/O error: {}", err),
+            FileParseError::Io(err) => write!(f, "I/O error: {err}"),
             FileParseError::InvalidFileFormat => write!(f, "Invalid file format."),
             FileParseError::BufferOverflow => write!(f, "Data out of bounds."),
             FileParseError::SliceConversionError => write!(f, "Error converting slice to array."),
             FileParseError::UnsupportedFeature(feature) => {
-                write!(f, "Unsupported feature: {}", feature)
+                write!(f, "Unsupported feature: {feature}")
             }
         }
     }

--- a/src/field.rs
+++ b/src/field.rs
@@ -1,3 +1,5 @@
+use crate::errors::FileParseError;
+
 #[derive(Debug, Clone, Copy)]
 pub struct Field<T> {
     pub value: T,
@@ -43,13 +45,14 @@ impl Field<u16> {
 
 impl Field<String> {
     /// Updates the buffer at the specified offset with the new UTF-8 encoded string.
-    pub fn update(&mut self, buffer: &mut [u8], new_value: &String) {
+    pub fn update(&mut self, buffer: &mut [u8], new_value: &String) -> Result<(), FileParseError> {
         self.value = new_value.to_string();
         let bytes: &[u8] = self.value.as_bytes();
         if bytes.len() > self.size {
-            panic!("New string value exceeds the allocated field size.");
+            return Err(FileParseError::BufferOverflow);
         }
 
         buffer[self.offset..self.offset + bytes.len()].copy_from_slice(bytes);
+        Ok(())
     }
 }

--- a/src/macho/header.rs
+++ b/src/macho/header.rs
@@ -19,33 +19,77 @@ impl MachHeader {
             return Err(errors::FileParseError::BufferOverflow);
         }
 
-        let magic = Field::new(u32::from_le_bytes(buffer[0..4].try_into().unwrap()), 0, 4);
-        let cpu_type = Field::new(u32::from_le_bytes(buffer[4..8].try_into().unwrap()), 4, 4);
-        let cpu_subtype = Field::new(u32::from_le_bytes(buffer[8..12].try_into().unwrap()), 8, 4);
+        let magic = Field::new(
+            u32::from_le_bytes(
+                buffer[0..4]
+                    .try_into()
+                    .map_err(|_| errors::FileParseError::BufferOverflow)?,
+            ),
+            0,
+            4,
+        );
+        let cpu_type = Field::new(
+            u32::from_le_bytes(
+                buffer[4..8]
+                    .try_into()
+                    .map_err(|_| errors::FileParseError::BufferOverflow)?,
+            ),
+            4,
+            4,
+        );
+        let cpu_subtype = Field::new(
+            u32::from_le_bytes(
+                buffer[8..12]
+                    .try_into()
+                    .map_err(|_| errors::FileParseError::BufferOverflow)?,
+            ),
+            8,
+            4,
+        );
         let file_type = Field::new(
-            u32::from_le_bytes(buffer[12..16].try_into().unwrap()),
+            u32::from_le_bytes(
+                buffer[12..16]
+                    .try_into()
+                    .map_err(|_| errors::FileParseError::BufferOverflow)?,
+            ),
             12,
             4,
         );
         let ncmds = Field::new(
-            u32::from_le_bytes(buffer[16..20].try_into().unwrap()),
+            u32::from_le_bytes(
+                buffer[16..20]
+                    .try_into()
+                    .map_err(|_| errors::FileParseError::BufferOverflow)?,
+            ),
             16,
             4,
         );
         let sizeofcmds = Field::new(
-            u32::from_le_bytes(buffer[20..24].try_into().unwrap()),
+            u32::from_le_bytes(
+                buffer[20..24]
+                    .try_into()
+                    .map_err(|_| errors::FileParseError::BufferOverflow)?,
+            ),
             20,
             4,
         );
         let flags = Field::new(
-            u32::from_le_bytes(buffer[24..28].try_into().unwrap()),
+            u32::from_le_bytes(
+                buffer[24..28]
+                    .try_into()
+                    .map_err(|_| errors::FileParseError::BufferOverflow)?,
+            ),
             24,
             4,
         );
 
         let reserved: Option<Field<u32>> = if buffer.len() >= 32 {
             Some(Field::new(
-                u32::from_le_bytes(buffer[28..32].try_into().unwrap()),
+                u32::from_le_bytes(
+                    buffer[28..32]
+                        .try_into()
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                ),
                 28,
                 4,
             ))

--- a/src/macho/load_command.rs
+++ b/src/macho/load_command.rs
@@ -25,7 +25,7 @@ impl LoadCommand {
                 u32::from_le_bytes(
                     buffer[current_offset..current_offset + 4]
                         .try_into()
-                        .unwrap(),
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
                 ),
                 current_offset,
                 4,
@@ -34,7 +34,7 @@ impl LoadCommand {
                 u32::from_le_bytes(
                     buffer[current_offset + 4..current_offset + 8]
                         .try_into()
-                        .unwrap(),
+                        .map_err(|_| errors::FileParseError::BufferOverflow)?,
                 ),
                 current_offset + 4,
                 4,

--- a/src/macho/mod.rs
+++ b/src/macho/mod.rs
@@ -58,7 +58,11 @@ impl MachO {
         }
 
         let magic = match buffer.get(0..4) {
-            Some(bytes) => u32::from_le_bytes(bytes.try_into().unwrap()),
+            Some(bytes) => u32::from_le_bytes(
+                bytes
+                    .try_into()
+                    .map_err(|_| errors::FileParseError::BufferOverflow)?,
+            ),
             None => return Err(errors::FileParseError::BufferOverflow),
         };
 

--- a/src/macho/segment.rs
+++ b/src/macho/segment.rs
@@ -31,42 +31,74 @@ impl Segment {
                     .trim_end_matches('\0')
                     .to_string();
                 let vmaddr = Field::new(
-                    u64::from_le_bytes(buffer[offset + 24..offset + 32].try_into().unwrap()),
+                    u64::from_le_bytes(
+                        buffer[offset + 24..offset + 32]
+                            .try_into()
+                            .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                    ),
                     offset + 24,
                     8,
                 );
                 let vmsize = Field::new(
-                    u64::from_le_bytes(buffer[offset + 32..offset + 40].try_into().unwrap()),
+                    u64::from_le_bytes(
+                        buffer[offset + 32..offset + 40]
+                            .try_into()
+                            .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                    ),
                     offset + 32,
                     8,
                 );
                 let fileoff = Field::new(
-                    u64::from_le_bytes(buffer[offset + 40..offset + 48].try_into().unwrap()),
+                    u64::from_le_bytes(
+                        buffer[offset + 40..offset + 48]
+                            .try_into()
+                            .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                    ),
                     offset + 40,
                     8,
                 );
                 let filesize = Field::new(
-                    u64::from_le_bytes(buffer[offset + 48..offset + 56].try_into().unwrap()),
+                    u64::from_le_bytes(
+                        buffer[offset + 48..offset + 56]
+                            .try_into()
+                            .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                    ),
                     offset + 48,
                     8,
                 );
                 let maxprot = Field::new(
-                    u32::from_le_bytes(buffer[offset + 56..offset + 60].try_into().unwrap()),
+                    u32::from_le_bytes(
+                        buffer[offset + 56..offset + 60]
+                            .try_into()
+                            .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                    ),
                     offset + 56,
                     4,
                 );
                 let initprot = Field::new(
-                    u32::from_le_bytes(buffer[offset + 60..offset + 64].try_into().unwrap()),
+                    u32::from_le_bytes(
+                        buffer[offset + 60..offset + 64]
+                            .try_into()
+                            .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                    ),
                     offset + 60,
                     4,
                 );
                 let nsects = Field::new(
-                    u32::from_le_bytes(buffer[offset + 64..offset + 68].try_into().unwrap()),
+                    u32::from_le_bytes(
+                        buffer[offset + 64..offset + 68]
+                            .try_into()
+                            .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                    ),
                     offset + 64,
                     4,
                 );
                 let flags = Field::new(
-                    u32::from_le_bytes(buffer[offset + 68..offset + 72].try_into().unwrap()),
+                    u32::from_le_bytes(
+                        buffer[offset + 68..offset + 72]
+                            .try_into()
+                            .map_err(|_| errors::FileParseError::BufferOverflow)?,
+                    ),
                     offset + 68,
                     4,
                 );

--- a/src/pe/header.rs
+++ b/src/pe/header.rs
@@ -26,7 +26,7 @@ impl fmt::Display for Architecture {
             Architecture::X64 => "x64",
             Architecture::Unknown => "Unknown",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -302,7 +302,7 @@ impl PE {
                 if diff > 0 {
                     self.buffer.splice(
                         alig_old_size_of_headers as usize..alig_old_size_of_headers as usize,
-                        std::iter::repeat(0).take(diff),
+                        std::iter::repeat_n(0, diff),
                     );
 
                     // Move the pointer_to_raw_data for each section based on the diff in SizeOfHeaders

--- a/tests/elf.rs
+++ b/tests/elf.rs
@@ -11,6 +11,7 @@ use std::fs;
 use toml::Value;
 
 use hexspell::elf; // <-- Testing module
+use hexspell::errors::FileParseError;
 
 /// ==========================================
 /// Testing reading and parsing in an ELF file
@@ -314,4 +315,12 @@ fn test_elf_parse() {
             );
         }
     }
+}
+
+/// Parsing an insufficient ELF buffer should return BufferOverflow
+#[test]
+fn test_elf_invalid_buffer() {
+    let buffer = vec![0u8; 10];
+    let result = elf::ELF::from_buffer(buffer);
+    assert!(matches!(result, Err(FileParseError::BufferOverflow)));
 }

--- a/tests/macho.rs
+++ b/tests/macho.rs
@@ -11,6 +11,7 @@ use std::fs;
 use toml::Value;
 
 use hexspell::macho; // <-- Testing module
+use hexspell::errors::FileParseError;
 
 /// ============================================
 /// Testing reading and parsing in a Mach-O file
@@ -112,4 +113,12 @@ fn test_macho_parse() {
             );
         }
     }
+}
+
+/// Parsing a buffer without a valid Mach-O magic number should fail
+#[test]
+fn test_macho_invalid_buffer() {
+    let buffer = vec![0u8; 4];
+    let result = macho::MachO::from_buffer(buffer);
+    assert!(matches!(result, Err(FileParseError::InvalidFileFormat)));
 }

--- a/tests/pe.rs
+++ b/tests/pe.rs
@@ -11,6 +11,7 @@ use std::fs;
 use toml::Value;
 
 use hexspell::pe; // <-- Testing module
+use hexspell::errors::FileParseError;
 
 /// ========================================
 /// Testing reading and parsing in a PE file
@@ -277,4 +278,12 @@ fn test_pe_shellcode_injection() {
 
     pe.write_file("tests/out/modified.exe")
         .expect("[!] Error writing new PE to disk");
+}
+
+/// Parsing an invalid PE buffer should return an error
+#[test]
+fn test_pe_invalid_buffer() {
+    let buffer = vec![0u8; 10];
+    let result = pe::PE::from_buffer(buffer);
+    assert!(matches!(result, Err(FileParseError::InvalidFileFormat)));
 }

--- a/tests/pe.rs
+++ b/tests/pe.rs
@@ -214,7 +214,8 @@ fn test_pe_parse() {
             let new_section_name = String::from(".test");
             pe.sections[0]
                 .name
-                .update(&mut pe.buffer, &new_section_name);
+                .update(&mut pe.buffer, &new_section_name)
+                .unwrap();
             assert_eq!(
                 pe.sections[0].name.value, new_section_name,
                 "Section name didnt changed"


### PR DESCRIPTION
### Added
- Added testing for ***PE***, ***ELF*** & ***Mach-O*** to ensure errors are raised on invalid formats.

### Fixed
- In ***ELF*** & ***Mach-O*** parsers, conversion errors now propagate to `FileParseError::BufferOverflow` instead of panicking.
- In ***PeSection*** string extraction, invalid ranges errors now propagate to  `FileParseError::BufferOverflow` instead of panicking.
- In ***Field*** values that exceed the attribute's limits now propagate `FileParseError::BufferOverflow` instead of panicking.